### PR TITLE
Updated Inventory to avoid equipping nulls

### DIFF
--- a/GameSim_UnityProject/ProjectDev_UnityProject/Assets/_Scenes/RicksTesting.unity
+++ b/GameSim_UnityProject/ProjectDev_UnityProject/Assets/_Scenes/RicksTesting.unity
@@ -2038,7 +2038,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 1365795171898284, guid: 431854977eab01b4cb0957719fd0fdad, type: 2}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 431854977eab01b4cb0957719fd0fdad, type: 2}

--- a/GameSim_UnityProject/ProjectDev_UnityProject/Assets/_Scripts/PlayerInventory.cs
+++ b/GameSim_UnityProject/ProjectDev_UnityProject/Assets/_Scripts/PlayerInventory.cs
@@ -14,10 +14,13 @@ public class PlayerInventory : MonoBehaviour
 		//Q & E Switch
 		if(Input.GetKeyDown(KeyCode.Q))
 		{
-			if(handPos == 0)
-				handPos = inventory.Length - 1;
-			else
-				handPos--;
+			int newPos = handPos;
+			newPos--;
+
+			if(newPos < 0 || inventory[newPos] == null )
+				newPos = loadPos - 1;
+
+			handPos = newPos;
 
 			inHand = inventory[handPos];
 			Debug.Log("Current Item: " + inHand.gameObject.name);
@@ -25,17 +28,22 @@ public class PlayerInventory : MonoBehaviour
 
 		if(Input.GetKeyDown(KeyCode.E))
 		{
-			if(handPos == inventory.Length - 1)
-				handPos = 0;
-			else 
-				handPos++;
+			int newPos = handPos;
+			newPos++;
+
+			if(newPos > inventory.Length - 1 || inventory[newPos] == null )
+				newPos = 0;
+
+			handPos = newPos;
 
 			inHand = inventory[handPos];
 			Debug.Log("Current Item: " + inHand.gameObject.name);
 		}
+
+		Debug.Log("HandPos: " + handPos);
 	
 		//if 'K' -> use
-		if(Input.GetKeyDown(KeyCode.K))
+		if(Input.GetKeyDown(KeyCode.K) && inHand != null)
 		{
 			inHand.Use();
 		}
@@ -43,7 +51,7 @@ public class PlayerInventory : MonoBehaviour
 
 	void OnTriggerEnter2D(Collider2D other)
 	{
-		if(other.tag == "KeyItem")
+		if(other.tag == "KeyItem" && loadPos < inventory.Length)
 		{
 			inventory[loadPos] = other.gameObject.GetComponent<Item>();
 			loadPos++;


### PR DESCRIPTION
Added code to not use items if they are null
Added code where Q and E selecting checks for nulls and outofbounds before switching
Switching now loops around to beginning or end of current non-null items
Added code to prevent adding to inventory when it is full
Fixed Issue #26